### PR TITLE
latestMessage method fix, can't return a relationship without attribute accessor, backport L4

### DIFF
--- a/src/Cmgmyr/Messenger/Models/Thread.php
+++ b/src/Cmgmyr/Messenger/Models/Thread.php
@@ -45,7 +45,7 @@ class Thread extends Eloquent
      *
      * @return \Cmgmyr\Messenger\Models\Message
      */
-    public function latestMessage()
+    public function getLatestMessageAttribute()
     {
         return $this->messages()->latest()->first();
     }

--- a/tests/EloquentThreadTest.php
+++ b/tests/EloquentThreadTest.php
@@ -51,7 +51,7 @@ class EloquentThreadTest extends TestCase
 
         $thread = $this->faktory->create('thread');
         $thread->messages()->saveMany([$oldMessage, $newMessage]);
-        $this->assertEquals($newMessage->body, $thread->latestMessage()->body);
+        $this->assertEquals($newMessage->body, $thread->latestMessage->body);
     }
 
     /** @test */


### PR DESCRIPTION
See #25 back ported for L4