### PR TITLE
Thread query scope fix

### DIFF
--- a/src/Cmgmyr/Messenger/Models/Thread.php
+++ b/src/Cmgmyr/Messenger/Models/Thread.php
@@ -161,7 +161,7 @@ class Thread extends Eloquent
      */
     public function scopeBetween($query, array $participants)
     {
-        $query->whereHas($this->getParticipantTable(), function ($query) use ($participants) {
+        $query->whereHas('participants', function ($query) use ($participants) {
             $query->whereIn('user_id', $participants)
                 ->groupBy('thread_id')
                 ->havingRaw('COUNT(thread_id)=' . count($participants));


### PR DESCRIPTION
Accordingly laravel documentation [Querying Relationship Existence](https://laravel.com/docs/5.1/eloquent-relationships#querying-relations) method `whereHas` should accept relation but not a table name.