### PR TITLE
Implement ability to define custom prefixed table names & models

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,5 +29,10 @@
             "Cmgmyr\\Messenger\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Cmgmyr\\Messenger\\Test\\": "tests/"
+        }
+    },
     "minimum-stability": "stable"
 }

--- a/src/Cmgmyr/Messenger/MessengerServiceProvider.php
+++ b/src/Cmgmyr/Messenger/MessengerServiceProvider.php
@@ -2,6 +2,10 @@
 
 namespace Cmgmyr\Messenger;
 
+use Cmgmyr\Messenger\Models\Message;
+use Cmgmyr\Messenger\Models\Models;
+use Cmgmyr\Messenger\Models\Participant;
+use Cmgmyr\Messenger\Models\Thread;
 use Illuminate\Support\ServiceProvider;
 
 class MessengerServiceProvider extends ServiceProvider
@@ -17,6 +21,9 @@ class MessengerServiceProvider extends ServiceProvider
             base_path('vendor/cmgmyr/messenger/src/config/config.php') => config_path('messenger.php'),
             base_path('vendor/cmgmyr/messenger/src/migrations') => base_path('database/migrations'),
         ]);
+
+        $this->setMessengerModels();
+        $this->setUserModel();
     }
 
     /**
@@ -29,5 +36,35 @@ class MessengerServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(
             base_path('vendor/cmgmyr/messenger/src/config/config.php'), 'messenger'
         );
+    }
+
+    private function setMessengerModels()
+    {
+        $config = $this->app->make('config');
+
+        Models::setMessageModel($config->get('messenger.message_model', Message::class));
+        Models::setThreadModel($config->get('messenger.thread_model', Thread::class));
+        Models::setParticipantModel($config->get('messenger.participant_model', Participant::class));
+
+        Models::setTables([
+            'messages' => $config->get('messenger.messages_table', Models::message()->getTable()),
+            'participants' => $config->get('messenger.participants_table', Models::participant()->getTable()),
+            'threads' => $config->get('messenger.threads_table', Models::thread()->getTable()),
+        ]);
+    }
+
+    private function setUserModel()
+    {
+        $config = $this->app->make('config');
+
+        $model = $config->get('auth.providers.users.model', function () use ($config) {
+            return $config->get('auth.model', $config->get('messenger.user_model'));
+        });
+
+        Models::setUserModel($model);
+
+        Models::setTables([
+            'users' => (new $model)->getTable(),
+        ]);
     }
 }

--- a/src/Cmgmyr/Messenger/Models/Message.php
+++ b/src/Cmgmyr/Messenger/Models/Message.php
@@ -2,8 +2,8 @@
 
 namespace Cmgmyr\Messenger\Models;
 
+use App\User;
 use Illuminate\Database\Eloquent\Model as Eloquent;
-use Illuminate\Support\Facades\Config;
 
 class Message extends Eloquent
 {
@@ -38,13 +38,23 @@ class Message extends Eloquent
     ];
 
     /**
+     * {@inheritDoc}
+     */
+    public function __construct(array $attributes = [])
+    {
+        $this->table = Models::table('messages');
+
+        parent::__construct($attributes);
+    }
+
+    /**
      * Thread relationship.
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function thread()
     {
-        return $this->belongsTo(Config::get('messenger.thread_model'), 'thread_id', 'id');
+        return $this->belongsTo(Models::classname(Thread::class), 'thread_id', 'id');
     }
 
     /**
@@ -54,7 +64,7 @@ class Message extends Eloquent
      */
     public function user()
     {
-        return $this->belongsTo(Config::get('messenger.user_model'), 'user_id');
+        return $this->belongsTo(Models::classname(User::class), 'user_id');
     }
 
     /**
@@ -64,7 +74,7 @@ class Message extends Eloquent
      */
     public function participants()
     {
-        return $this->hasMany(Config::get('messenger.participant_model'), 'thread_id', 'thread_id');
+        return $this->hasMany(Models::classname(Participant::class), 'thread_id', 'thread_id');
     }
 
     /**

--- a/src/Cmgmyr/Messenger/Models/Models.php
+++ b/src/Cmgmyr/Messenger/Models/Models.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Cmgmyr\Messenger\Models;
+
+use App\User;
+
+class Models
+{
+    /**
+     * Map for the messenger's models.
+     *
+     * @var array
+     */
+    protected static $models = [];
+
+    /**
+     * Map for the messenger's tables.
+     *
+     * @var array
+     */
+    protected static $tables = [];
+
+    /**
+     * Set the model to be used for threads.
+     *
+     * @param string $model
+     */
+    public static function setMessageModel($model)
+    {
+        static::$models[Message::class] = $model;
+    }
+
+    /**
+     * Set the model to be used for participants.
+     *
+     * @param  string $model
+     * @return void
+     */
+    public static function setParticipantModel($model)
+    {
+        static::$models[Participant::class] = $model;
+    }
+
+    /**
+     * Set the model to be used for threads.
+     *
+     * @param  string $model
+     * @return void
+     */
+    public static function setThreadModel($model)
+    {
+        static::$models[Thread::class] = $model;
+    }
+
+    /**
+     * Set the model to be used for users.
+     *
+     * @param  string  $model
+     * @return void
+     */
+    public static function setUserModel($model)
+    {
+        static::$models[User::class] = $model;
+    }
+
+    /**
+     * Set custom table names.
+     *
+     * @param  array $map
+     * @return void
+     */
+    public static function setTables(array $map)
+    {
+        static::$tables = array_merge(static::$tables, $map);
+    }
+
+    /**
+     * Get a custom table name mapping for the given table.
+     *
+     * @param  string $table
+     * @return string
+     */
+    public static function table($table)
+    {
+        if (isset(static::$tables[$table])) {
+            return static::$tables[$table];
+        }
+
+        return $table;
+    }
+
+    /**
+     * Get the classname mapping for the given model.
+     *
+     * @param  string $model
+     * @return string
+     */
+    public static function classname($model)
+    {
+        if (isset(static::$models[$model])) {
+            return static::$models[$model];
+        }
+
+        return $model;
+    }
+
+    /**
+     * Get an instance of the messages model.
+     *
+     * @param  array $attributes
+     * @return \Cmgmyr\Messenger\Models\Message
+     */
+    public static function message(array $attributes = [])
+    {
+        return static::make(Message::class, $attributes);
+    }
+
+    /**
+     * Get an instance of the participants model.
+     *
+     * @param  array $attributes
+     * @return \Cmgmyr\Messenger\Models\Participant
+     */
+    public static function participant(array $attributes = [])
+    {
+        return static::make(Participant::class, $attributes);
+    }
+
+    /**
+     * Get an instance of the threads model.
+     *
+     * @param  array $attributes
+     * @return \Cmgmyr\Messenger\Models\Thread
+     */
+    public static function thread(array $attributes = [])
+    {
+        return static::make(Thread::class, $attributes);
+    }
+
+    /**
+     * Get an instance of the user model.
+     *
+     * @param  array  $attributes
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public static function user(array $attributes = [])
+    {
+        return static::make(User::class, $attributes);
+    }
+
+    /**
+     * Get an instance of the given model.
+     *
+     * @param  string $model
+     * @param  array $attributes
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    protected static function make($model, array $attributes = [])
+    {
+        $model = static::classname($model);
+
+        return new $model($attributes);
+    }
+}

--- a/src/Cmgmyr/Messenger/Models/Participant.php
+++ b/src/Cmgmyr/Messenger/Models/Participant.php
@@ -2,9 +2,9 @@
 
 namespace Cmgmyr\Messenger\Models;
 
+use App\User;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Support\Facades\Config;
 
 class Participant extends Eloquent
 {
@@ -32,13 +32,23 @@ class Participant extends Eloquent
     protected $dates = ['created_at', 'updated_at', 'deleted_at', 'last_read'];
 
     /**
+     * {@inheritDoc}
+     */
+    public function __construct(array $attributes = [])
+    {
+        $this->table = Models::table('participants');
+
+        parent::__construct($attributes);
+    }
+
+    /**
      * Thread relationship.
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function thread()
     {
-        return $this->belongsTo(Config::get('messenger.thread_model'), 'thread_id', 'id');
+        return $this->belongsTo(Models::classname(Thread::class), 'thread_id', 'id');
     }
 
     /**
@@ -48,6 +58,6 @@ class Participant extends Eloquent
      */
     public function user()
     {
-        return $this->belongsTo(Config::get('messenger.user_model'), 'user_id');
+        return $this->belongsTo(Models::classname(User::class), 'user_id');
     }
 }

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -1,11 +1,22 @@
 <?php
 
 return [
-    'user_model' => 'App\User',
 
-    'message_model' => 'Cmgmyr\Messenger\Models\Message',
+    'user_model' => App\User::class,
 
-    'participant_model' => 'Cmgmyr\Messenger\Models\Participant',
+    'message_model' => Cmgmyr\Messenger\Models\Message::class,
 
-    'thread_model' => 'Cmgmyr\Messenger\Models\Thread',
+    'participant_model' => Cmgmyr\Messenger\Models\Participant::class,
+
+    'thread_model' => Cmgmyr\Messenger\Models\Thread::class,
+
+    /**
+     * Define custom database table names.
+     */
+
+    'messages_table' => null,
+
+    'participants_table' => null,
+
+    'threads_table' => null,
 ];

--- a/src/migrations/2014_10_28_175635_create_threads_table.php
+++ b/src/migrations/2014_10_28_175635_create_threads_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use Cmgmyr\Messenger\Models\Models;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
@@ -12,7 +13,7 @@ class CreateThreadsTable extends Migration
      */
     public function up()
     {
-        Schema::create('threads', function (Blueprint $table) {
+        Schema::create(Models::table('threads'), function (Blueprint $table) {
             $table->increments('id');
             $table->string('subject');
             $table->timestamps();
@@ -26,6 +27,6 @@ class CreateThreadsTable extends Migration
      */
     public function down()
     {
-        Schema::drop('threads');
+        Schema::drop(Models::table('threads'));
     }
 }

--- a/src/migrations/2014_10_28_175710_create_messages_table.php
+++ b/src/migrations/2014_10_28_175710_create_messages_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use Cmgmyr\Messenger\Models\Models;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
@@ -12,7 +13,7 @@ class CreateMessagesTable extends Migration
      */
     public function up()
     {
-        Schema::create('messages', function (Blueprint $table) {
+        Schema::create(Models::table('messages'), function (Blueprint $table) {
             $table->increments('id');
             $table->integer('thread_id')->unsigned();
             $table->integer('user_id')->unsigned();
@@ -28,6 +29,6 @@ class CreateMessagesTable extends Migration
      */
     public function down()
     {
-        Schema::drop('messages');
+        Schema::drop(Models::table('messages'));
     }
 }

--- a/src/migrations/2014_10_28_180224_create_participants_table.php
+++ b/src/migrations/2014_10_28_180224_create_participants_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use Cmgmyr\Messenger\Models\Models;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
@@ -12,7 +13,7 @@ class CreateParticipantsTable extends Migration
      */
     public function up()
     {
-        Schema::create('participants', function (Blueprint $table) {
+        Schema::create(Models::table('participants'), function (Blueprint $table) {
             $table->increments('id');
             $table->integer('thread_id')->unsigned();
             $table->integer('user_id')->unsigned();
@@ -28,6 +29,6 @@ class CreateParticipantsTable extends Migration
      */
     public function down()
     {
-        Schema::drop('participants');
+        Schema::drop(Models::table('participants'));
     }
 }

--- a/src/migrations/2014_11_03_154831_add_soft_deletes_to_participants_table.php
+++ b/src/migrations/2014_11_03_154831_add_soft_deletes_to_participants_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use Cmgmyr\Messenger\Models\Models;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
@@ -12,7 +13,7 @@ class AddSoftDeletesToParticipantsTable extends Migration
      */
     public function up()
     {
-        Schema::table('participants', function (Blueprint $table) {
+        Schema::table(Models::table('participants'), function (Blueprint $table) {
             $table->softDeletes();
         });
     }
@@ -24,7 +25,7 @@ class AddSoftDeletesToParticipantsTable extends Migration
      */
     public function down()
     {
-        Schema::table('participants', function (Blueprint $table) {
+        Schema::table(Models::table('participants'), function (Blueprint $table) {
             $table->dropSoftDeletes();
         });
     }

--- a/src/migrations/2014_11_10_083449_add_nullable_to_last_read_in_participants_table.php
+++ b/src/migrations/2014_11_10_083449_add_nullable_to_last_read_in_participants_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use Cmgmyr\Messenger\Models\Models;
 use Illuminate\Database\Migrations\Migration;
 
 class AddNullableToLastReadInParticipantsTable extends Migration
@@ -11,7 +12,7 @@ class AddNullableToLastReadInParticipantsTable extends Migration
      */
     public function up()
     {
-        DB::statement('ALTER TABLE `' . DB::getTablePrefix() . 'participants` CHANGE COLUMN `last_read` `last_read` timestamp NULL ON UPDATE CURRENT_TIMESTAMP DEFAULT CURRENT_TIMESTAMP;');
+        DB::statement('ALTER TABLE `' . DB::getTablePrefix() . Models::table('participants') . '` CHANGE COLUMN `last_read` `last_read` timestamp NULL ON UPDATE CURRENT_TIMESTAMP DEFAULT CURRENT_TIMESTAMP;');
     }
 
     /**

--- a/src/migrations/2014_11_20_131739_alter_last_read_in_participants_table.php
+++ b/src/migrations/2014_11_20_131739_alter_last_read_in_participants_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use Cmgmyr\Messenger\Models\Models;
 use Illuminate\Database\Migrations\Migration;
 
 class AlterLastReadInParticipantsTable extends Migration
@@ -11,7 +12,7 @@ class AlterLastReadInParticipantsTable extends Migration
      */
     public function up()
     {
-        DB::statement('ALTER TABLE `' . DB::getTablePrefix() . 'participants` CHANGE COLUMN `last_read` `last_read` timestamp NULL DEFAULT NULL;');
+        DB::statement('ALTER TABLE `' . DB::getTablePrefix() . Models::table('participants') . '` CHANGE COLUMN `last_read` `last_read` timestamp NULL DEFAULT NULL;');
     }
 
     /**

--- a/src/migrations/2014_12_04_124531_add_softdeletes_to_threads_table.php
+++ b/src/migrations/2014_12_04_124531_add_softdeletes_to_threads_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use Cmgmyr\Messenger\Models\Models;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
@@ -12,7 +13,7 @@ class AddSoftdeletesToThreadsTable extends Migration
      */
     public function up()
     {
-        Schema::table('threads', function (Blueprint $table) {
+        Schema::table(Models::table('threads'), function (Blueprint $table) {
             $table->softDeletes();
         });
     }
@@ -24,7 +25,7 @@ class AddSoftdeletesToThreadsTable extends Migration
      */
     public function down()
     {
-        Schema::table('threads', function (Blueprint $table) {
+        Schema::table(Models::table('threads'), function (Blueprint $table) {
             $table->dropSoftDeletes();
         });
     }

--- a/tests/CustomModelsTest.php
+++ b/tests/CustomModelsTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Cmgmyr\Messenger\Test;
+
+use Cmgmyr\Messenger\Models\Message;
+use Cmgmyr\Messenger\Models\Models;
+use Cmgmyr\Messenger\Models\Participant;
+use Cmgmyr\Messenger\Models\Thread;
+use Cmgmyr\Messenger\Test\Models\CustomMessage;
+use Cmgmyr\Messenger\Test\Models\CustomParticipant;
+use Cmgmyr\Messenger\Test\Models\CustomThread;
+
+class CustomModelsTest extends TestCase
+{
+    /** @test */
+    public function it_can_use_custom_message_model()
+    {
+        $this->setMessageCustomModel();
+        $this->assertEquals(CustomMessage::class, get_class(Models::message()));
+        $this->unsetMessageCustomModel();
+    }
+
+    /** @test */
+    public function it_can_use_custom_participant_model()
+    {
+        $this->setParticipantCustomModel();
+        $this->assertEquals(CustomParticipant::class, get_class(Models::participant()));
+        $this->unsetParticipantCustomModel();
+    }
+
+    /** @test */
+    public function it_can_use_custom_thread_model()
+    {
+        $this->setThreadCustomModel();
+        $this->assertEquals(CustomThread::class, get_class(Models::thread()));
+        $this->unsetThreadCustomModel();
+    }
+
+    /** @test */
+    public function it_can_use_custom_table()
+    {
+        $this->setMessageCustomModel();
+        $this->setMessageCustomTable();
+
+        $this->assertEquals('custom_messages', Models::table('messages'));
+
+        $this->unsetMessageCustomModel();
+        $this->unsetMessageCustomTable();
+    }
+
+    /** :TODO: test */
+    public function it_can_get_custom_model_table_property()
+    {
+        $this->setMessageCustomModel();
+
+        $this->assertEquals('custom_messages', Models::message()->getTable());
+
+        $this->unsetMessageCustomModel();
+    }
+
+    protected function setMessageCustomModel()
+    {
+        Models::setMessageModel(CustomMessage::class);
+    }
+
+    protected function setParticipantCustomModel()
+    {
+        Models::setParticipantModel(CustomParticipant::class);
+    }
+
+    protected function setThreadCustomModel()
+    {
+        Models::setThreadModel(CustomThread::class);
+    }
+
+    protected function unsetMessageCustomModel()
+    {
+        Models::setMessageModel(Message::class);
+    }
+
+    protected function unsetParticipantCustomModel()
+    {
+        Models::setParticipantModel(Participant::class);
+    }
+
+    protected function unsetThreadCustomModel()
+    {
+        Models::setThreadModel(Thread::class);
+    }
+
+    protected function setMessageCustomTable()
+    {
+        Models::setTables([
+            'messages' => 'custom_messages',
+        ]);
+    }
+
+    protected function unsetMessageCustomTable()
+    {
+        Models::setTables([
+            'messages' => 'messages',
+        ]);
+    }
+}

--- a/tests/EloquentMessageTest.php
+++ b/tests/EloquentMessageTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Cmgmyr\Messenger\tests;
+namespace Cmgmyr\Messenger\Test;
 
 use Illuminate\Database\Eloquent\Model as Eloquent;
 

--- a/tests/EloquentThreadTest.php
+++ b/tests/EloquentThreadTest.php
@@ -1,8 +1,10 @@
 <?php
 
-namespace Cmgmyr\Messenger\tests;
+namespace Cmgmyr\Messenger\Test;
 
 use Carbon\Carbon;
+use Cmgmyr\Messenger\Models\Models;
+use Cmgmyr\Messenger\Models\Participant;
 use Cmgmyr\Messenger\Models\Thread;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use ReflectionClass;
@@ -23,7 +25,7 @@ class EloquentThreadTest extends TestCase
      */
     protected static function getMethod($name)
     {
-        $class = new ReflectionClass('Cmgmyr\Messenger\Models\Thread');
+        $class = new ReflectionClass(Thread::class);
         $method = $class->getMethod($name);
         $method->setAccessible(true);
 
@@ -197,7 +199,7 @@ class EloquentThreadTest extends TestCase
 
         $newParticipant = $thread->getParticipantFromUser($userId);
 
-        $this->assertInstanceOf('\Cmgmyr\Messenger\Models\Participant', $newParticipant);
+        $this->assertInstanceOf(Participant::class, $newParticipant);
     }
 
     /**
@@ -237,8 +239,7 @@ class EloquentThreadTest extends TestCase
     {
         $method = self::getMethod('createSelectString');
         $thread = new Thread();
-        $tableName = 'users';
-        $thread->setUsersTable($tableName);
+        $tableName = Models::table('users');
 
         $columns = ['name'];
         $select = $method->invokeArgs($thread, [$columns]);
@@ -253,7 +254,6 @@ class EloquentThreadTest extends TestCase
     public function it_should_get_participants_string()
     {
         $thread = $this->faktory->create('thread');
-        $thread->setUsersTable('users');
 
         $participant_1 = $this->faktory->build('participant');
         $participant_2 = $this->faktory->build('participant', ['user_id' => 2]);

--- a/tests/MessagableTraitTest.php
+++ b/tests/MessagableTraitTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Cmgmyr\Messenger\tests;
+namespace Cmgmyr\Messenger\Test;
 
 use Carbon\Carbon;
 use Cmgmyr\Messenger\Traits\Messagable;

--- a/tests/Models/CustomMessage.php
+++ b/tests/Models/CustomMessage.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Cmgmyr\Messenger\Test\Models;
+
+use Cmgmyr\Messenger\Models\Message;
+
+class CustomMessage extends Message
+{
+    protected $table = 'custom_messages';
+}

--- a/tests/Models/CustomParticipant.php
+++ b/tests/Models/CustomParticipant.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Cmgmyr\Messenger\Test\Models;
+
+use Cmgmyr\Messenger\Models\Message;
+
+class CustomParticipant extends Message
+{
+    protected $table = 'custom_participants';
+}

--- a/tests/Models/CustomThread.php
+++ b/tests/Models/CustomThread.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Cmgmyr\Messenger\Test\Models;
+
+use Cmgmyr\Messenger\Models\Message;
+
+class CustomThread extends Message
+{
+    protected $table = 'custom_threads';
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Cmgmyr\Messenger\tests;
+namespace Cmgmyr\Messenger\Test;
 
 date_default_timezone_set('America/New_York');
 


### PR DESCRIPTION
This PR resolving couple of things to make package more customizable:
- added an ability to have configurable table names for each model;
- clean way to get table names;
- clean way to get models & their class names;
- support of default Laravel's 5.x Auth configuration + fallback to your previous implementation.

This is an improved version of [my previous suggesion](https://github.com/cmgmyr/laravel-messenger/issues/78).

The bad part of this PR that I haven't wrote any test for the new behaviour, I've just updated current ones to bypass the checks.