### PR TITLE
Fix counter and getting of all unread messages

### DIFF
--- a/src/Cmgmyr/Messenger/Models/Thread.php
+++ b/src/Cmgmyr/Messenger/Models/Thread.php
@@ -328,18 +328,21 @@ class Thread extends Eloquent
     /**
      * Returns array of unread messages in thread for given user.
      *
-     * @param $user_id
+     * @param $userId
      *
-     * @return array
+     * @return \Illuminate\Support\Collection
      */
-    public function userUnreadMessages($user_id)
+    public function userUnreadMessages($userId)
     {
         $messages = $this->messages()->get();
-        $participant = $this->getParticipantFromUser($user_id);
+        $participant = $this->getParticipantFromUser($userId);
         if (!$participant) {
-            return [];
+            return collect();
         }
-        $unread = array();
+        if (!$participant->last_read) {
+            return collect($messages);
+        }
+        $unread = [];
         $i = count($messages) - 1;
         while ($i) {
             if ($messages[$i]->updated_at->gt($participant->last_read)) {
@@ -350,22 +353,25 @@ class Thread extends Eloquent
             --$i;
         }
 
-        return $unread;
+        return collect($unread);
     }
 
     /**
      * Returns count of unread messages in thread for given user.
      *
-     * @param $user_id
+     * @param $userId
      *
      * @return int
      */
-    public function userUnreadMessagesCount($user_id)
+    public function userUnreadMessagesCount($userId)
     {
         $messages = $this->messages()->get();
-        $participant = $this->getParticipantFromUser($user_id);
+        $participant = $this->getParticipantFromUser($userId);
         if (!$participant) {
             return 0;
+        }
+        if (!$participant->last_read) {
+            return count($messages);
         }
         $count = 0;
         $i = count($messages) - 1;

--- a/tests/EloquentThreadTest.php
+++ b/tests/EloquentThreadTest.php
@@ -286,6 +286,7 @@ class EloquentThreadTest extends TestCase
         $this->assertFalse($thread->hasParticipant(3));
     }
 
+    /** @test */
     public function it_should_get_all_unread_messages_for_user()
     {
         $thread = $this->faktory->create('thread');
@@ -298,11 +299,13 @@ class EloquentThreadTest extends TestCase
             'body'       => "Message 1",
         ]);
 
-
         $thread->participants()->saveMany([$participant_1, $participant_2]);
         $thread->messages()->saveMany([$message_1]);
 
         $thread->markAsRead($participant_2->user_id);
+
+        // Simulate delay after last read
+        sleep(1);
 
         $message_2 = $this->faktory->build('message', [
             'created_at' => Carbon::now(),
@@ -311,10 +314,14 @@ class EloquentThreadTest extends TestCase
 
         $thread->messages()->saveMany([$message_2]);
 
+        $this->assertEquals("Message 1", $thread->userUnreadMessages(1)->first()->body);
+        $this->assertCount(2, $thread->userUnreadMessages(1));
+
         $this->assertEquals("Message 2", $thread->userUnreadMessages(2)->first()->body);
-        $this->assertCount(1, $thread->userUnreadMessages(2)->count());
+        $this->assertCount(1, $thread->userUnreadMessages(2));
     }
 
+    /** @test */
     public function it_should_get_count_of_all_unread_messages_for_user()
     {
         $thread = $this->faktory->create('thread');
@@ -327,11 +334,13 @@ class EloquentThreadTest extends TestCase
             'body'       => "Message 1",
         ]);
 
-
         $thread->participants()->saveMany([$participant_1, $participant_2]);
         $thread->messages()->saveMany([$message_1]);
 
         $thread->markAsRead($participant_2->user_id);
+
+        // Simulate delay after last read
+        sleep(1);
 
         $message_2 = $this->faktory->build('message', [
             'created_at' => Carbon::now(),
@@ -339,6 +348,8 @@ class EloquentThreadTest extends TestCase
         ]);
 
         $thread->messages()->saveMany([$message_2]);
+
+        $this->assertEquals(2, $thread->userUnreadMessagesCount(1));
 
         $this->assertEquals(1, $thread->userUnreadMessagesCount(2));
     }


### PR DESCRIPTION
Fix for #80 

There could be a situation when participant's `last_read` attribute will be equal to `null`. Then `userUnreadMessagesCount()` and `userUnreadMessages()` will throw an exceptions.

Unit tests were disabled. After their activation I've done some tweaks to make them work correctly and add checks for an issue I've described above.

Because unit tests method `it_should_get_all_unread_messages_for_user()` tried to work with `userUnreadMessages()` output using iterator thru collection `userUnreadMessages()` now wrap array in `\Illuminate\Support\Collection`.