### PR TITLE
Implemented unread threads as a relationship on Messagable Trait

### DIFF
--- a/src/Cmgmyr/Messenger/Traits/Messagable.php
+++ b/src/Cmgmyr/Messenger/Traits/Messagable.php
@@ -45,46 +45,34 @@ trait Messagable
     }
 
     /**
+     * Unread threads as a relationship
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\belongsToMany
+     */
+    public function unreadThreads()
+    {
+        return $this->threads()
+            ->whereRaw(Models::table('threads') . '.updated_at > '
+                    . Models::table('participants') . '.last_read');
+    }
+
+    /**
      * Returns the new messages count for user.
      *
      * @return int
      */
     public function newMessagesCount()
     {
-        return count($this->threadsWithNewMessages());
+        return $this->unreadThreads()->count();
     }
 
     /**
-     * Returns all threads with new messages.
+     * Returns the id of all threads with new messages.
      *
      * @return array
      */
     public function threadsWithNewMessages()
     {
-        $threadsWithNewMessages = [];
-
-        $participants = Models::participant()->where('user_id', $this->id)->lists('last_read', 'thread_id');
-
-        /**
-         * @todo: see if we can fix this more in the future.
-         * Illuminate\Foundation is not available through composer, only in laravel/framework which
-         * I don't want to include as a dependency for this package...it's overkill. So let's
-         * exclude this check in the testing environment.
-         */
-        if (getenv('APP_ENV') == 'testing' || !str_contains(\Illuminate\Foundation\Application::VERSION, '5.0')) {
-            $participants = $participants->all();
-        }
-
-        if ($participants) {
-            $threads = Models::thread()->whereIn('id', array_keys($participants))->get();
-
-            foreach ($threads as $thread) {
-                if ($thread->updated_at > $participants[$thread->id]) {
-                    $threadsWithNewMessages[] = $thread->id;
-                }
-            }
-        }
-
-        return $threadsWithNewMessages;
+        return $this->unreadThreads()->lists(Models::table('threads') . '.id');
     }
 }


### PR DESCRIPTION
Hello,

What do you think of implementing unread messages as a relationship on Messageable Trait?
This way it is possible use it to query the full thread when needed, also to simplify threadsWithNewMessages().

Tests looks ok, let me know if you see any issue I didn't think of.
Cheers