### PR TITLE
Fixed last commit on Messagable trait

### DIFF
--- a/src/Cmgmyr/Messenger/Traits/Messagable.php
+++ b/src/Cmgmyr/Messenger/Traits/Messagable.php
@@ -52,8 +52,9 @@ trait Messagable
     public function unreadThreads()
     {
         return $this->threads()
-            ->whereRaw(Models::table('threads') . '.updated_at > '
-                    . Models::table('participants') . '.last_read');
+            ->whereRaw('(' . Models::table('threads') . '.updated_at > '
+                    . Models::table('participants') . '.last_read'
+                    . ' OR ' . Models::table('participants') . '.last_read IS NULL)');
     }
 
     /**
@@ -73,6 +74,9 @@ trait Messagable
      */
     public function threadsWithNewMessages()
     {
-        return $this->unreadThreads()->lists(Models::table('threads') . '.id');
+        $threads = $this->unreadThreads()->lists(Models::table('threads') . '.id');
+
+        //Always return array (L5.0 vs L5.1 lists behaviour change)
+        return is_array($threads) ? $threads : $threads->all();
     }
 }

--- a/tests/MessagableTraitTest.php
+++ b/tests/MessagableTraitTest.php
@@ -48,6 +48,39 @@ class MessagableTraitTest extends TestCase
         $this->assertEquals(1, $user->newMessagesCount());
     }
 
+	/** @test */
+    public function it_should_get_all_threads_with_new_messages_last_read_null()
+    {
+        $user = User::create(
+            [
+                'name' => 'John Doe',
+                'email' => 'john@example.com',
+                'notify' => 'y',
+            ]
+        );
+
+        $thread = $this->faktory->create('thread');
+        $user_1 = $this->faktory->build('participant', ['user_id' => $user->id, 'last_read' => NULL]);
+        $user_2 = $this->faktory->build('participant', ['user_id' => 2]);
+        $thread->participants()->saveMany([$user_1, $user_2]);
+
+        $message_1 = $this->faktory->build('message', ['user_id' => 2]);
+        $thread->messages()->saveMany([$message_1]);
+
+        $thread2 = $this->faktory->create('thread');
+        $user_1b = $this->faktory->build('participant', ['user_id' => 3, 'last_read' => NULL]);
+        $user_2b = $this->faktory->build('participant', ['user_id' => 2]);
+        $thread2->participants()->saveMany([$user_1b, $user_2b]);
+
+        $message_1b = $this->faktory->build('message', ['user_id' => 2]);
+        $thread2->messages()->saveMany([$message_1b]);
+
+        $threads = $user->threadsWithNewMessages();
+        $this->assertEquals(1, $threads[0]);
+
+        $this->assertEquals(1, $user->newMessagesCount());
+    }
+
     /** @test */
     public function it_should_get_participant_threads()
     {


### PR DESCRIPTION
- New messages in unread thread were not showing
- Converting return value of threadsWithNewMessages to array as suggested by @Gummibeer
- Added test to cover the issue