### PR TITLE
refactor lists/pluck references…

### DIFF
--- a/src/Cmgmyr/Messenger/Models/Thread.php
+++ b/src/Cmgmyr/Messenger/Models/Thread.php
@@ -111,7 +111,9 @@ class Thread extends Eloquent
      */
     public function participantsUserIds($userId = null)
     {
-        $users = $this->participants()->withTrashed()->pluck('user_id');
+        $users = $this->participants()->withTrashed()->select('user_id')->get()->map(function ($participant) {
+            return $participant->user_id;
+        })->toArray();
 
         if ($userId) {
             $users[] = $userId;
@@ -294,9 +296,7 @@ class Thread extends Eloquent
             $participantNames->where($usersTable . '.id', '!=', $userId);
         }
 
-        $userNames = $participantNames->pluck($usersTable . '.name');
-
-        return implode(', ', $userNames);
+        return $participantNames->implode('name', ', ');
     }
 
     /**

--- a/src/Cmgmyr/Messenger/Models/Thread.php
+++ b/src/Cmgmyr/Messenger/Models/Thread.php
@@ -113,13 +113,13 @@ class Thread extends Eloquent
     {
         $users = $this->participants()->withTrashed()->select('user_id')->get()->map(function ($participant) {
             return $participant->user_id;
-        })->toArray();
+        });
 
         if ($userId) {
-            $users[] = $userId;
+            $users->push($userId);
         }
 
-        return $users;
+        return $users->toArray();
     }
 
     /**

--- a/src/Cmgmyr/Messenger/Traits/Messagable.php
+++ b/src/Cmgmyr/Messenger/Traits/Messagable.php
@@ -51,40 +51,20 @@ trait Messagable
      */
     public function newThreadsCount()
     {
-        return count($this->threadsWithNewMessages());
+        return $this->threadsWithNewMessages()->count();
     }
 
     /**
      * Returns all threads with new messages.
      *
-     * @return array
+     * @return \Illuminate\Database\Eloquent\Relations\belongsToMany
      */
     public function threadsWithNewMessages()
     {
-        $threadsWithNewMessages = [];
-
-        $participants = Models::participant()->where('user_id', $this->id)->pluck('last_read', 'thread_id');
-
-        /**
-         * @todo: see if we can fix this more in the future.
-         * Illuminate\Foundation is not available through composer, only in laravel/framework which
-         * I don't want to include as a dependency for this package...it's overkill. So let's
-         * exclude this check in the testing environment.
-         */
-        if (getenv('APP_ENV') == 'testing' || !str_contains(\Illuminate\Foundation\Application::VERSION, '5.0')) {
-            $participants = $participants->all();
-        }
-
-        if ($participants) {
-            $threads = Models::thread()->whereIn('id', array_keys($participants))->get();
-
-            foreach ($threads as $thread) {
-                if ($thread->updated_at > $participants[$thread->id]) {
-                    $threadsWithNewMessages[] = $thread->id;
-                }
-            }
-        }
-
-        return $threadsWithNewMessages;
+        return $this->threads()
+            ->where(function ($q) {
+                $q->whereNull(Models::table('participants') . '.last_read');
+                $q->orWhere(Models::table('threads') . '.updated_at', '>', $this->getConnection()->raw(Models::table('participants') . '.last_read'));
+            })->get();
     }
 }

--- a/tests/EloquentThreadTest.php
+++ b/tests/EloquentThreadTest.php
@@ -107,8 +107,8 @@ class EloquentThreadTest extends TestCase
     public function it_should_get_all_thread_participants()
     {
         $thread = $this->faktory->create('thread');
-        $participants = $thread->participantsUserIds();
-        $this->assertCount(0, $participants);
+        $participantIds = $thread->participantsUserIds();
+        $this->assertCount(0, $participantIds);
 
         $user_1 = $this->faktory->build('participant');
         $user_2 = $this->faktory->build('participant', ['user_id' => 2]);
@@ -116,10 +116,11 @@ class EloquentThreadTest extends TestCase
 
         $thread->participants()->saveMany([$user_1, $user_2, $user_3]);
 
-        $participants = $thread->participantsUserIds();
-        $this->assertCount(3, $participants);
+        $participantIds = $thread->participantsUserIds();
+        $this->assertCount(3, $participantIds);
+        $this->assertEquals(2, $participantIds[1]);
 
-        $this->assertInternalType('object', $participants);
+        $this->assertInternalType('array', $participantIds);
     }
 
     /** @test */

--- a/tests/EloquentThreadTest.php
+++ b/tests/EloquentThreadTest.php
@@ -120,6 +120,10 @@ class EloquentThreadTest extends TestCase
         $this->assertCount(3, $participantIds);
         $this->assertEquals(2, $participantIds[1]);
 
+        $participantIds = $thread->participantsUserIds(999);
+        $this->assertCount(4, $participantIds);
+        $this->assertEquals(999, end($participantIds));
+
         $this->assertInternalType('array', $participantIds);
     }
 

--- a/tests/MessagableTraitTest.php
+++ b/tests/MessagableTraitTest.php
@@ -43,7 +43,7 @@ class MessagableTraitTest extends TestCase
         $thread2->messages()->saveMany([$message_1b]);
 
         $threads = $user->threadsWithNewMessages();
-        $this->assertEquals(1, $threads[0]);
+        $this->assertEquals(1, $threads->first()->id);
 
         $this->assertEquals(1, $user->newThreadsCount());
     }


### PR DESCRIPTION
so Laravel 5.[0,1,2] installs will work correctly

now also returning the full Eloquent relationship from threadsWithNewMessages() instead of an array of ids

refs #154 