### PR TITLE
Added Schema facade dependency to be up to date with L5.3 migrations

### DIFF
--- a/src/migrations/2014_10_28_175635_create_threads_table.php
+++ b/src/migrations/2014_10_28_175635_create_threads_table.php
@@ -3,6 +3,7 @@
 use Cmgmyr\Messenger\Models\Models;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class CreateThreadsTable extends Migration
 {

--- a/src/migrations/2014_10_28_175710_create_messages_table.php
+++ b/src/migrations/2014_10_28_175710_create_messages_table.php
@@ -3,6 +3,7 @@
 use Cmgmyr\Messenger\Models\Models;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class CreateMessagesTable extends Migration
 {

--- a/src/migrations/2014_10_28_180224_create_participants_table.php
+++ b/src/migrations/2014_10_28_180224_create_participants_table.php
@@ -3,6 +3,7 @@
 use Cmgmyr\Messenger\Models\Models;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class CreateParticipantsTable extends Migration
 {

--- a/src/migrations/2014_11_03_154831_add_soft_deletes_to_participants_table.php
+++ b/src/migrations/2014_11_03_154831_add_soft_deletes_to_participants_table.php
@@ -3,6 +3,7 @@
 use Cmgmyr\Messenger\Models\Models;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class AddSoftDeletesToParticipantsTable extends Migration
 {

--- a/src/migrations/2014_12_04_124531_add_softdeletes_to_threads_table.php
+++ b/src/migrations/2014_12_04_124531_add_softdeletes_to_threads_table.php
@@ -3,6 +3,7 @@
 use Cmgmyr\Messenger\Models\Models;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class AddSoftdeletesToThreadsTable extends Migration
 {


### PR DESCRIPTION
Laravel 5.3+ migrations now using Schema facade explicitly. This should work on all previous Laravel versions as well.