### PR TITLE
Publishing assets improved

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,9 +46,9 @@ Add the service provider to `config/app.php` under `providers`:
         Cmgmyr\Messenger\MessengerServiceProvider::class,
     ]
 
-Publish Assets
+Publish config:
 
-    php artisan vendor:publish --provider="Cmgmyr\Messenger\MessengerServiceProvider"
+    php artisan vendor:publish --provider="Cmgmyr\Messenger\MessengerServiceProvider" --tag="config"
 	
 Update config file to reference your User Model:
 
@@ -61,6 +61,10 @@ Create a `users` table if you do not have one already. If you need one, simply u
     'messages_table' => 'messenger_messages',
     'participants_table' => 'messenger_participants',
     'threads_table' => 'messenger_threads',
+    
+Publish migrations:
+
+    php artisan vendor:publish --provider="Cmgmyr\Messenger\MessengerServiceProvider" --tag="migrations"
 
 Migrate your database:
 

--- a/src/Cmgmyr/Messenger/MessengerServiceProvider.php
+++ b/src/Cmgmyr/Messenger/MessengerServiceProvider.php
@@ -17,10 +17,15 @@ class MessengerServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->publishes([
-            base_path('vendor/cmgmyr/messenger/src/config/config.php') => config_path('messenger.php'),
-            base_path('vendor/cmgmyr/messenger/src/migrations') => base_path('database/migrations'),
-        ]);
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                base_path('vendor/cmgmyr/messenger/src/config/config.php') => config_path('messenger.php'),
+            ], 'config');
+
+            $this->publishes([
+                base_path('vendor/cmgmyr/messenger/src/migrations') => base_path('database/migrations'),
+            ], 'migrations');
+        }
 
         $this->setMessengerModels();
         $this->setUserModel();


### PR DESCRIPTION
- Publishing assets separated into groups to have more flexibility like force republishing config or migrations independently of each other.
- Publish command is only registering from the console application for minor optimization.
- **Publish assets** section in README separated on **Publish config** & **Publish migrations** sections to show how user can perform both of them.