### PR TITLE
reference the user model's primary key directly

### DIFF
--- a/src/Cmgmyr/Messenger/Models/Models.php
+++ b/src/Cmgmyr/Messenger/Models/Models.php
@@ -2,7 +2,7 @@
 
 namespace Cmgmyr\Messenger\Models;
 
-use App\User;
+use Illuminate\Database\Eloquent\Model;
 
 class Models
 {
@@ -60,7 +60,7 @@ class Models
      */
     public static function setUserModel($model)
     {
-        static::$models[User::class] = $model;
+        static::$models[Model::class] = $model;
     }
 
     /**
@@ -145,7 +145,7 @@ class Models
      */
     public static function user(array $attributes = [])
     {
-        return static::make(User::class, $attributes);
+        return static::make(Model::class, $attributes);
     }
 
     /**

--- a/src/Cmgmyr/Messenger/Models/Thread.php
+++ b/src/Cmgmyr/Messenger/Models/Thread.php
@@ -285,16 +285,17 @@ class Thread extends Eloquent
     {
         $participantsTable = Models::table('participants');
         $usersTable = Models::table('users');
+        $userPrimaryKey = Models::user()->getKeyName();
 
         $selectString = $this->createSelectString($columns);
 
         $participantNames = $this->getConnection()->table($usersTable)
-            ->join($participantsTable, $usersTable . '.id', '=', $participantsTable . '.user_id')
+            ->join($participantsTable, $usersTable . '.' . $userPrimaryKey, '=', $participantsTable . '.user_id')
             ->where($participantsTable . '.thread_id', $this->id)
             ->select($this->getConnection()->raw($selectString));
 
         if ($userId !== null) {
-            $participantNames->where($usersTable . '.id', '!=', $userId);
+            $participantNames->where($usersTable . '.' . $userPrimaryKey, '!=', $userId);
         }
 
         return $participantNames->implode('name', ', ');

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Cmgmyr\Messenger\Test\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,6 +5,7 @@ namespace Cmgmyr\Messenger\Test;
 date_default_timezone_set('America/New_York');
 
 use AdamWathan\Faktory\Faktory;
+use Cmgmyr\Messenger\Models\Models;
 use Illuminate\Database\Capsule\Manager as DB;
 use Orchestra\Testbench\TestCase as Orchestra;
 
@@ -29,6 +30,9 @@ class TestCase extends Orchestra
             require __DIR__ . '/factories.php';
         };
         $load_factories($this->faktory);
+
+        $userModel = User::class;
+        Models::setUserModel($userModel);
     }
 
     /**


### PR DESCRIPTION
Since the `User` model could be dynamic, we should be referencing the primary key name dynamically. So a projects "User" model could be something like `App\Account` with a primary key of `user_id` and still work.