### PR TITLE
QueryException in Messagable.php

### DIFF
--- a/src/Cmgmyr/Messenger/Traits/Messagable.php
+++ b/src/Cmgmyr/Messenger/Traits/Messagable.php
@@ -64,7 +64,7 @@ trait Messagable
         return $this->threads()
             ->where(function ($q) {
                 $q->whereNull(Models::table('participants') . '.last_read');
-                $q->orWhere(Models::table('threads') . '.updated_at', '>', $this->getConnection()->raw(Models::table('participants') . '.last_read'));
+                $q->orWhere(Models::table('threads') . '.updated_at', '>', Models::table('participants') . '.last_read');
             })->get();
     }
 }


### PR DESCRIPTION
The call to $this->getConnection()->raw() is causing a QueryException on Laravel 5.1:
`Column not found: 1054 Unknown column 'participants.last_read' in 'where clause' `

Due to the fact that it is stripping out the column prefix like so:
`participants.last_read instead of `L995b5BiSQ_participants`.`last_read``