### PR TITLE
Adding Many To Many relationship User<->Thread

### DIFF
--- a/src/Cmgmyr/Messenger/Models/Thread.php
+++ b/src/Cmgmyr/Messenger/Models/Thread.php
@@ -72,6 +72,19 @@ class Thread extends Eloquent
         return $this->hasMany(Models::classname(Participant::class), 'thread_id', 'id');
     }
 
+    
+    /**
+     * User relationship.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function users()
+    {
+        return $this->belongsToMany('App\User', 'participants' ,'thread_id', 'user_id');
+    }
+
+    
+    
     /**
      * Returns the user object that created the thread.
      *


### PR DESCRIPTION
Using Participant table as pivot table:

Corresponding relationship in `App\User` Model.

 /**
     * Thread relationship.
     *
     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
     */
    public function threads()
    {
        return $this->belongsToMany(Models::classname(Thread::class), 'participants' ,'user_id', 'thread_id');
    }