### PR TITLE
Add custom participants model support in thread users

### DIFF
--- a/src/Cmgmyr/Messenger/Models/Thread.php
+++ b/src/Cmgmyr/Messenger/Models/Thread.php
@@ -79,7 +79,7 @@ class Thread extends Eloquent
      */
     public function users()
     {
-        return $this->belongsToMany(Models::user(), 'participants', 'thread_id', 'user_id');
+        return $this->belongsToMany(Models::classname('User'), Models::table('participants'), 'thread_id', 'user_id');
     }
 
     /**


### PR DESCRIPTION
Add ability to use custom participants table name.

Minor optimization of relation. Because `Models::user()` returns User model instance, while `Models::classname('User')` will return only class name.