### PR TITLE
Fix exception when trying to get creator of thread without messages

### DIFF
--- a/src/Cmgmyr/Messenger/Models/Thread.php
+++ b/src/Cmgmyr/Messenger/Models/Thread.php
@@ -95,7 +95,9 @@ class Thread extends Eloquent
      */
     public function creator()
     {
-        return $this->messages()->withTrashed()->oldest()->first()->user;
+        $firstMessage = $this->messages()->withTrashed()->oldest()->first();
+
+        return $firstMessage ? $firstMessage->user : null;
     }
 
     /**

--- a/tests/CustomModelsTest.php
+++ b/tests/CustomModelsTest.php
@@ -6,9 +6,9 @@ use Cmgmyr\Messenger\Models\Message;
 use Cmgmyr\Messenger\Models\Models;
 use Cmgmyr\Messenger\Models\Participant;
 use Cmgmyr\Messenger\Models\Thread;
-use Cmgmyr\Messenger\Test\Models\CustomMessage;
-use Cmgmyr\Messenger\Test\Models\CustomParticipant;
-use Cmgmyr\Messenger\Test\Models\CustomThread;
+use Cmgmyr\Messenger\Test\Stubs\Models\CustomMessage;
+use Cmgmyr\Messenger\Test\Stubs\Models\CustomParticipant;
+use Cmgmyr\Messenger\Test\Stubs\Models\CustomThread;
 
 class CustomModelsTest extends TestCase
 {

--- a/tests/EloquentThreadTest.php
+++ b/tests/EloquentThreadTest.php
@@ -495,4 +495,22 @@ class EloquentThreadTest extends TestCase
 
         $this->assertEquals('Chris Gmyr', $thread->creator()->name);
     }
+
+    /**
+     * @test
+     *
+     * TODO: Need to get real creator of the thread without messages in future versions.
+     */
+    public function it_should_get_the_null_creator_of_a_thread_without_messages()
+    {
+        $thread = $this->faktory->create('thread');
+
+        $user_1 = $this->faktory->build('participant');
+        $user_2 = $this->faktory->build('participant', ['user_id' => 2]);
+        $user_3 = $this->faktory->build('participant', ['user_id' => 3]);
+
+        $thread->participants()->saveMany([$user_1, $user_2, $user_3]);
+
+        $this->assertNull($thread->creator());
+    }
 }

--- a/tests/Stubs/Models/CustomMessage.php
+++ b/tests/Stubs/Models/CustomMessage.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Cmgmyr\Messenger\Test\Models;
+namespace Cmgmyr\Messenger\Test\Stubs\Models;
 
 use Cmgmyr\Messenger\Models\Message;
 

--- a/tests/Stubs/Models/CustomParticipant.php
+++ b/tests/Stubs/Models/CustomParticipant.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Cmgmyr\Messenger\Test\Models;
+namespace Cmgmyr\Messenger\Test\Stubs\Models;
 
 use Cmgmyr\Messenger\Models\Message;
 

--- a/tests/Stubs/Models/CustomThread.php
+++ b/tests/Stubs/Models/CustomThread.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Cmgmyr\Messenger\Test\Models;
+namespace Cmgmyr\Messenger\Test\Stubs\Models;
 
 use Cmgmyr\Messenger\Models\Message;
 

--- a/tests/Stubs/Models/User.php
+++ b/tests/Stubs/Models/User.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Cmgmyr\Messenger\Test\Models;
+namespace Cmgmyr\Messenger\Test\Stubs\Models;
 
 use Illuminate\Database\Eloquent\Model;
 


### PR DESCRIPTION
Related to #229 
- Added check if messages exists (because right now creator is the user who left first message in thread).
- Added unit test case for trying to get creator of the thread without messages.
- Additionally I've moved Unit tests Stubs to separate folder to keep tests folder more structured.