### PR TITLE
Drop only exists database tables

### DIFF
--- a/migrations/2014_10_28_175635_create_threads_table.php
+++ b/migrations/2014_10_28_175635_create_threads_table.php
@@ -28,6 +28,6 @@ class CreateThreadsTable extends Migration
      */
     public function down()
     {
-        Schema::drop(Models::table('threads'));
+        Schema::dropIfExists(Models::table('threads'));
     }
 }

--- a/migrations/2014_10_28_175710_create_messages_table.php
+++ b/migrations/2014_10_28_175710_create_messages_table.php
@@ -30,6 +30,6 @@ class CreateMessagesTable extends Migration
      */
     public function down()
     {
-        Schema::drop(Models::table('messages'));
+        Schema::dropIfExists(Models::table('messages'));
     }
 }

--- a/migrations/2014_10_28_180224_create_participants_table.php
+++ b/migrations/2014_10_28_180224_create_participants_table.php
@@ -30,6 +30,6 @@ class CreateParticipantsTable extends Migration
      */
     public function down()
     {
-        Schema::drop(Models::table('participants'));
+        Schema::dropIfExists(Models::table('participants'));
     }
 }


### PR DESCRIPTION
To follow Laravel default migration files it will be better to call `dropIfExists` method instead of `drop`. If table was dropped already - migration rollback process wouldn't be broken.