### PR TITLE
Add PHP7.2 to Travis environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
 
 # This triggers builds to run on the new TravisCI infrastructure.
 # See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/


### PR DESCRIPTION
2 days ago PHP 7.2.0 Release Candidate 2 was released. Travis CI already supporting PHP7.2 environment already.