### PR TITLE
Fix custom classes parents in Tests

### DIFF
--- a/tests/Stubs/Models/CustomParticipant.php
+++ b/tests/Stubs/Models/CustomParticipant.php
@@ -2,9 +2,9 @@
 
 namespace Cmgmyr\Messenger\Test\Stubs\Models;
 
-use Cmgmyr\Messenger\Models\Message;
+use Cmgmyr\Messenger\Models\Participant;
 
-class CustomParticipant extends Message
+class CustomParticipant extends Participant
 {
     protected $table = 'custom_participants';
 }

--- a/tests/Stubs/Models/CustomThread.php
+++ b/tests/Stubs/Models/CustomThread.php
@@ -2,9 +2,9 @@
 
 namespace Cmgmyr\Messenger\Test\Stubs\Models;
 
-use Cmgmyr\Messenger\Models\Message;
+use Cmgmyr\Messenger\Models\Thread;
 
-class CustomThread extends Message
+class CustomThread extends Thread
 {
     protected $table = 'custom_threads';
 }


### PR DESCRIPTION
`CustomParticipant` and `CustomThread` models in tests extended wrong models. This wouldn't affect on tests but better to fix this misuse.