### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "illuminate/config": "~5.0",
-        "illuminate/support": "~5.0",
-        "illuminate/database": "~5.0",
+        "illuminate/config": "5.0.* || 5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*",
+        "illuminate/support": "5.0.* || 5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*",
+        "illuminate/database": "5.0.* || 5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*",
         "nesbot/carbon": "~1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.