### PR TITLE
Thread method getBySubject call where from static

### DIFF
--- a/src/Models/Thread.php
+++ b/src/Models/Thread.php
@@ -125,11 +125,11 @@ class Thread extends Eloquent
      * Returns all threads by subject.
      *
      * @param string $subject
-     * @return self
+     * @return \Illuminate\Database\Eloquent\Collection|static[]
      */
     public static function getBySubject($subject)
     {
-        return self::where('subject', 'like', $subject)->get();
+        return static::where('subject', 'like', $subject)->get();
     }
 
     /**


### PR DESCRIPTION
This behavior important for the extended Thread model, otherwise collection of `Cmgmyr\Messenger\Models\Thread` models will be returned instead of extended ones.

Additionally I've fixed DocBlock return type to reflect that Collection will be returned.