### PR TITLE
Thread method getAllLatest call latest from static

### DIFF
--- a/src/Models/Thread.php
+++ b/src/Models/Thread.php
@@ -114,11 +114,11 @@ class Thread extends Eloquent
     /**
      * Returns all of the latest threads by updated_at date.
      *
-     * @return self
+     * @return \Illuminate\Database\Query\Builder|static
      */
     public static function getAllLatest()
     {
-        return self::latest('updated_at');
+        return static::latest('updated_at');
     }
 
     /**


### PR DESCRIPTION
This behavior important for the extended Thread model, otherwise Query Builder will be called on `Cmgmyr\Messenger\Models\Thread` model instead of extended one.

Additionally I've fixed DocBlock return type to reflect that Query Builder will be returned.