### PR TITLE
Prioritize package user_model config value over auth user

### DIFF
--- a/src/MessengerServiceProvider.php
+++ b/src/MessengerServiceProvider.php
@@ -92,8 +92,8 @@ class MessengerServiceProvider extends ServiceProvider
     {
         $config = $this->app->make('config');
 
-        $model = $config->get('auth.providers.users.model', function () use ($config) {
-            return $config->get('auth.model', $config->get('messenger.user_model'));
+        $model = $config->get('messenger.user_model', function () use ($config) {
+            return $config->get('auth.providers.users.model', $config->get('auth.model'));
         });
 
         Models::setUserModel($model);


### PR DESCRIPTION
This should fix #293

Now `auth.providers.users.model` config value has max priority and package ignores `user_model` config value. So we are not able to use custom user model (if it differs from default auth user model).