### PR TITLE
Fix applications with custom user models first install

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -2,7 +2,7 @@
 
 return [
 
-    'user_model' => App\User::class,
+    'user_model' => null,
 
     'message_model' => Cmgmyr\Messenger\Models\Message::class,
 


### PR DESCRIPTION
Fixes #300 

This PR removes hardcoded User model value from config file, otherwise there is issues on first install and you are not able to publish configuration file.

>  Illuminate\Foundation\ComposerScripts::postAutoloadDump
>  php artisan package:discover
> 
> In MessengerServiceProvider.php line 102:
>                               
>  Class 'App\User' not found

By default package will use `auth.providers.users.model` value to resolve User model, what covers most of the use cases.