### PR TITLE
comment config user_model

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -2,7 +2,7 @@
 
 return [
 
-    'user_model' => null,
+    // 'user_model' => App\Models\User::class,
 
     'message_model' => Cmgmyr\Messenger\Models\Message::class,
 


### PR DESCRIPTION
After publishing `2.16.1` I ran into an issue while installing a new version of Laravel 5.6 that was failing to load the user model.

<img width="822" alt="screen shot 2018-06-16 at 8 46 03 am" src="https://user-images.githubusercontent.com/4693481/41498802-eefc48be-7143-11e8-94e0-924b27a5889d.png">

Because `user_model` was set (to `null`) in the config file, Laravel found this as valid within our service provider. Then trying to set the actual model to `null` failed. By commenting out the line in the config file fixes this, and I added a sensible, custom, default.