### PR TITLE
Add Laravel 5.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,14 @@
 language: php
 
 php:
-  - 5.6
-  - 7.0
   - 7.1
   - 7.2
+  - 7.3
   - nightly
 
 matrix:
   allow_failures:
-  - php: 7.2
   - php: nightly
-
-# This triggers builds to run on the new TravisCI infrastructure.
-# See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
-sudo: false
 
 ## Cache composer
 cache:

--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/config": "~5.0",
-        "illuminate/support": "~5.0",
-        "illuminate/database": "~5.0"
+        "illuminate/config": ">=5.5 <6.0",
+        "illuminate/support": ">=5.5 <6.0",
+        "illuminate/database": ">=5.5 <6.0"
     },
     "require-dev": {
         "adamwathan/faktory": "0.3.*",

--- a/composer.json
+++ b/composer.json
@@ -12,17 +12,16 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
+        "php": "^7.1.3",
         "illuminate/config": "~5.0",
         "illuminate/support": "~5.0",
-        "illuminate/database": "~5.0",
-        "nesbot/carbon": "~1.0"
+        "illuminate/database": "~5.0"
     },
     "require-dev": {
         "adamwathan/faktory": "0.3.*",
         "friendsofphp/php-cs-fixer": "^2.5",
-        "orchestra/testbench": "~3.0",
-        "phpunit/phpunit": "4.*|5.*"
+        "orchestra/testbench": "~3.5.0|~3.6.0|~3.7.0|~3.8.0",
+        "phpunit/phpunit": "^7.0|^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require-dev": {
         "adamwathan/faktory": "0.3.*",
         "friendsofphp/php-cs-fixer": "^2.5",
-        "orchestra/testbench": "~3.5.0|~3.6.0|~3.7.0|~3.8.0",
+        "orchestra/testbench": "~3.0",
         "phpunit/phpunit": "^7.0|^8.0"
     },
     "autoload": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
 >
     <testsuites>
         <testsuite name="Messenger Test Suite">
@@ -20,6 +19,10 @@
         <env name="CACHE_DRIVER" value="array"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="QUEUE_DRIVER" value="sync"/>
+        <server name="APP_ENV" value="testing"/>
+        <server name="CACHE_DRIVER" value="array"/>
+        <server name="SESSION_DRIVER" value="array"/>
+        <server name="QUEUE_DRIVER" value="sync"/>
     </php>
     <filter>
         <whitelist>

--- a/src/Models/Thread.php
+++ b/src/Models/Thread.php
@@ -2,11 +2,11 @@
 
 namespace Cmgmyr\Messenger\Models;
 
-use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 
 class Thread extends Eloquent
 {

--- a/tests/EloquentMessageTest.php
+++ b/tests/EloquentMessageTest.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model as Eloquent;
 
 class EloquentMessageTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         Eloquent::unguard();

--- a/tests/EloquentThreadTest.php
+++ b/tests/EloquentThreadTest.php
@@ -2,16 +2,16 @@
 
 namespace Cmgmyr\Messenger\Test;
 
-use Carbon\Carbon;
 use Cmgmyr\Messenger\Models\Models;
 use Cmgmyr\Messenger\Models\Participant;
 use Cmgmyr\Messenger\Models\Thread;
 use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Support\Carbon;
 use ReflectionClass;
 
 class EloquentThreadTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         Eloquent::unguard();
@@ -22,6 +22,8 @@ class EloquentThreadTest extends TestCase
      *
      * @param $name
      * @return \ReflectionMethod
+     *
+     * @throws \ReflectionException
      */
     protected static function getMethod($name)
     {

--- a/tests/MessagableTraitTest.php
+++ b/tests/MessagableTraitTest.php
@@ -2,14 +2,14 @@
 
 namespace Cmgmyr\Messenger\Test;
 
-use Carbon\Carbon;
 use Cmgmyr\Messenger\Models\Thread;
 use Cmgmyr\Messenger\Traits\Messagable;
 use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Support\Carbon;
 
 class MessagableTraitTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         Eloquent::unguard();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -19,7 +19,7 @@ class TestCase extends Orchestra
     /**
      * Set up the database, migrations, and initial data.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
Closes #312 

This PR adds:
- Laravel 5.8 support
- Allows to use Carbon 2.0 as well as Carbon 1.0

Additionally it sets minimum version of PHP 7.1.3 as all new Laravel versions has, because Laravel 5.8 MUST have methods with `void` return type and it's allowed only since PHP 7.1.

All versions below Laravel 5.5 cannot be supported because Illuminate\Support\Carbon has appeared only since v5.5.