### PR TITLE
remove references to Input facade (Laravel 6.x upgrade)

### DIFF
--- a/examples/MessagesController.php
+++ b/examples/MessagesController.php
@@ -9,7 +9,7 @@ use Cmgmyr\Messenger\Models\Participant;
 use Cmgmyr\Messenger\Models\Thread;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Input;
+use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Session;
 
 class MessagesController extends Controller
@@ -80,7 +80,7 @@ class MessagesController extends Controller
      */
     public function store()
     {
-        $input = Input::all();
+        $input = Request::all();
 
         $thread = Thread::create([
             'subject' => $input['subject'],
@@ -101,7 +101,7 @@ class MessagesController extends Controller
         ]);
 
         // Recipients
-        if (Input::has('recipients')) {
+        if (Request::has('recipients')) {
             $thread->addParticipant($input['recipients']);
         }
 
@@ -130,7 +130,7 @@ class MessagesController extends Controller
         Message::create([
             'thread_id' => $thread->id,
             'user_id' => Auth::id(),
-            'body' => Input::get('message'),
+            'body' => Request::input('message'),
         ]);
 
         // Add replier as a participant
@@ -142,8 +142,8 @@ class MessagesController extends Controller
         $participant->save();
 
         // Recipients
-        if (Input::has('recipients')) {
-            $thread->addParticipant(Input::get('recipients'));
+        if (Request::has('recipients')) {
+            $thread->addParticipant(Request::input('recipients'));
         }
 
         return redirect()->route('messages.show', $id);


### PR DESCRIPTION
The Input facade [has been removed in Laravel 6](https://laravel.com/docs/6.x/upgrade#the-input-facade), the example controller should be updated to use the Request facade instead.