### PR TITLE
remove additional types to keep backwards compatibility

### DIFF
--- a/src/MessengerServiceProvider.php
+++ b/src/MessengerServiceProvider.php
@@ -17,7 +17,7 @@ class MessengerServiceProvider extends ServiceProvider
      * @return void
      * @throws BindingResolutionException
      */
-    public function boot(): void
+    public function boot()
     {
         $this->offerPublishing();
         $this->setMessengerModels();
@@ -29,7 +29,7 @@ class MessengerServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    public function register(): void
+    public function register()
     {
         $this->configure();
     }
@@ -39,7 +39,7 @@ class MessengerServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    protected function configure(): void
+    protected function configure()
     {
         $this->mergeConfigFrom(
             __DIR__ . '/../config/config.php',
@@ -52,7 +52,7 @@ class MessengerServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    protected function offerPublishing(): void
+    protected function offerPublishing()
     {
         if ($this->app->runningInConsole()) {
             $this->publishes([
@@ -71,7 +71,7 @@ class MessengerServiceProvider extends ServiceProvider
      * @return void
      * @throws BindingResolutionException
      */
-    protected function setMessengerModels(): void
+    protected function setMessengerModels()
     {
         $config = $this->app->make('config');
 
@@ -92,7 +92,7 @@ class MessengerServiceProvider extends ServiceProvider
      * @return void
      * @throws BindingResolutionException
      */
-    protected function setUserModel(): void
+    protected function setUserModel()
     {
         $config = $this->app->make('config');
 

--- a/src/Models/Message.php
+++ b/src/Models/Message.php
@@ -60,7 +60,7 @@ class Message extends Eloquent
      *
      * @codeCoverageIgnore
      */
-    public function thread(): BelongsTo
+    public function thread()
     {
         return $this->belongsTo(Models::classname(Thread::class), 'thread_id', 'id');
     }
@@ -72,7 +72,7 @@ class Message extends Eloquent
      *
      * @codeCoverageIgnore
      */
-    public function user(): BelongsTo
+    public function user()
     {
         return $this->belongsTo(Models::user(), 'user_id');
     }
@@ -84,7 +84,7 @@ class Message extends Eloquent
      *
      * @codeCoverageIgnore
      */
-    public function participants(): HasMany
+    public function participants()
     {
         return $this->hasMany(Models::classname(Participant::class), 'thread_id', 'thread_id');
     }
@@ -94,7 +94,7 @@ class Message extends Eloquent
      *
      * @return HasMany
      */
-    public function recipients(): HasMany
+    public function recipients()
     {
         return $this->participants()->where('user_id', '!=', $this->user_id);
     }
@@ -106,7 +106,7 @@ class Message extends Eloquent
      * @param mixed $userId
      * @return Builder
      */
-    public function scopeUnreadForUser(Builder $query, $userId): Builder
+    public function scopeUnreadForUser(Builder $query, $userId)
     {
         return $query->has('thread')
             ->where('user_id', '!=', $userId)

--- a/src/Models/Models.php
+++ b/src/Models/Models.php
@@ -32,7 +32,7 @@ class Models
      *
      * @param string $model
      */
-    public static function setMessageModel(string $model): void
+    public static function setMessageModel($model)
     {
         static::$models[Message::class] = $model;
     }
@@ -42,7 +42,7 @@ class Models
      *
      * @param string $model
      */
-    public static function setParticipantModel(string $model): void
+    public static function setParticipantModel($model)
     {
         static::$models[Participant::class] = $model;
     }
@@ -52,7 +52,7 @@ class Models
      *
      * @param string $model
      */
-    public static function setThreadModel(string $model): void
+    public static function setThreadModel($model)
     {
         static::$models[Thread::class] = $model;
     }
@@ -62,7 +62,7 @@ class Models
      *
      * @param string $model
      */
-    public static function setUserModel(string $model): void
+    public static function setUserModel($model)
     {
         static::$models[self::$userModelLookupKey] = $model;
     }
@@ -72,7 +72,7 @@ class Models
      *
      * @param array $map
      */
-    public static function setTables(array $map): void
+    public static function setTables(array $map)
     {
         static::$tables = array_merge(static::$tables, $map);
     }
@@ -83,7 +83,7 @@ class Models
      * @param string $table
      * @return string
      */
-    public static function table(string $table): string
+    public static function table($table)
     {
         return static::$tables[$table] ?? $table;
     }
@@ -94,7 +94,7 @@ class Models
      * @param string $model
      * @return string
      */
-    public static function classname(string $model): string
+    public static function classname($model)
     {
         return static::$models[$model] ?? $model;
     }
@@ -138,7 +138,7 @@ class Models
      * @param  array  $attributes
      * @return Model
      */
-    public static function user(array $attributes = []): Model
+    public static function user(array $attributes = [])
     {
         return static::make(self::$userModelLookupKey, $attributes);
     }
@@ -150,7 +150,7 @@ class Models
      * @param  array $attributes
      * @return Model
      */
-    protected static function make(string $model, array $attributes = []): Model
+    protected static function make($model, array $attributes = [])
     {
         $model = static::classname($model);
 

--- a/src/Models/Participant.php
+++ b/src/Models/Participant.php
@@ -48,7 +48,7 @@ class Participant extends Eloquent
      *
      * @codeCoverageIgnore
      */
-    public function thread(): BelongsTo
+    public function thread()
     {
         return $this->belongsTo(Models::classname(Thread::class), 'thread_id', 'id');
     }
@@ -60,7 +60,7 @@ class Participant extends Eloquent
      *
      * @codeCoverageIgnore
      */
-    public function user(): BelongsTo
+    public function user()
     {
         return $this->belongsTo(Models::user(), 'user_id');
     }

--- a/src/Models/Thread.php
+++ b/src/Models/Thread.php
@@ -66,7 +66,7 @@ class Thread extends Eloquent
      *
      * @codeCoverageIgnore
      */
-    public function messages(): HasMany
+    public function messages()
     {
         return $this->hasMany(Models::classname(Message::class), 'thread_id', 'id');
     }
@@ -88,7 +88,7 @@ class Thread extends Eloquent
      *
      * @codeCoverageIgnore
      */
-    public function participants(): HasMany
+    public function participants()
     {
         return $this->hasMany(Models::classname(Participant::class), 'thread_id', 'id');
     }
@@ -100,7 +100,7 @@ class Thread extends Eloquent
      *
      * @codeCoverageIgnore
      */
-    public function users(): BelongsToMany
+    public function users()
     {
         return $this->belongsToMany(Models::classname('User'), Models::table('participants'), 'thread_id', 'user_id');
     }
@@ -110,7 +110,7 @@ class Thread extends Eloquent
      *
      * @return null|Models::user()|\Illuminate\Database\Eloquent\Model
      */
-    public function creator(): ?Eloquent
+    public function creator()
     {
         if ($this->creatorCache === null) {
             $firstMessage = $this->messages()->withTrashed()->oldest()->first();
@@ -149,7 +149,7 @@ class Thread extends Eloquent
      *
      * @return array
      */
-    public function participantsUserIds($userId = null): array
+    public function participantsUserIds($userId = null)
     {
         $users = $this->participants()->withTrashed()->select('user_id')->get()->map(function ($participant) {
             return $participant->user_id;
@@ -170,7 +170,7 @@ class Thread extends Eloquent
      *
      * @return Builder
      */
-    public function scopeForUser(Builder $query, $userId): Builder
+    public function scopeForUser(Builder $query, $userId)
     {
         $participantsTable = Models::table('participants');
         $threadsTable = Models::table('threads');
@@ -189,7 +189,7 @@ class Thread extends Eloquent
      *
      * @return Builder
      */
-    public function scopeForUserWithNewMessages(Builder $query, $userId): Builder
+    public function scopeForUserWithNewMessages(Builder $query, $userId)
     {
         $participantTable = Models::table('participants');
         $threadsTable = Models::table('threads');
@@ -212,7 +212,7 @@ class Thread extends Eloquent
      *
      * @return Builder
      */
-    public function scopeBetweenOnly(Builder $query, array $participants): Builder
+    public function scopeBetweenOnly(Builder $query, array $participants)
     {
         return $query->whereHas('participants', function (Builder $builder) use ($participants) {
             return $builder->whereIn('user_id', $participants)
@@ -230,7 +230,7 @@ class Thread extends Eloquent
      *
      * @return Builder
      */
-    public function scopeBetween(Builder $query, array $participants): Builder
+    public function scopeBetween(Builder $query, array $participants)
     {
         return $query->whereHas('participants', function (Builder $q) use ($participants) {
             $q->whereIn('user_id', $participants)
@@ -247,7 +247,7 @@ class Thread extends Eloquent
      *
      * @return void
      */
-    public function addParticipant($userId): void
+    public function addParticipant($userId)
     {
         $userIds = is_array($userId) ? $userId : func_get_args();
 
@@ -266,7 +266,7 @@ class Thread extends Eloquent
      *
      * @return void
      */
-    public function removeParticipant($userId): void
+    public function removeParticipant($userId)
     {
         $userIds = is_array($userId) ? $userId : func_get_args();
 
@@ -280,7 +280,7 @@ class Thread extends Eloquent
      *
      * @return void
      */
-    public function markAsRead($userId): void
+    public function markAsRead($userId)
     {
         try {
             $participant = $this->getParticipantFromUser($userId);
@@ -298,7 +298,7 @@ class Thread extends Eloquent
      *
      * @return bool
      */
-    public function isUnread($userId): bool
+    public function isUnread($userId)
     {
         try {
             $participant = $this->getParticipantFromUser($userId);
@@ -333,7 +333,7 @@ class Thread extends Eloquent
      *
      * @return void
      */
-    public function activateAllParticipants(): void
+    public function activateAllParticipants()
     {
         $participants = $this->participants()->onlyTrashed()->get();
         foreach ($participants as $participant) {
@@ -349,7 +349,7 @@ class Thread extends Eloquent
      *
      * @return string
      */
-    public function participantsString($userId = null, array $columns = ['name']): string
+    public function participantsString($userId = null, array $columns = ['name'])
     {
         $participantsTable = Models::table('participants');
         $usersTable = Models::table('users');
@@ -376,7 +376,7 @@ class Thread extends Eloquent
      *
      * @return bool
      */
-    public function hasParticipant($userId): bool
+    public function hasParticipant($userId)
     {
         $participants = $this->participants()->where('user_id', '=', $userId);
 
@@ -390,7 +390,7 @@ class Thread extends Eloquent
      *
      * @return string
      */
-    protected function createSelectString(array $columns): string
+    protected function createSelectString($columns)
     {
         $dbDriver = $this->getConnection()->getDriverName();
         $tablePrefix = $this->getConnection()->getTablePrefix();
@@ -423,7 +423,7 @@ class Thread extends Eloquent
      *
      * @return Collection
      */
-    public function userUnreadMessages($userId): Collection
+    public function userUnreadMessages($userId)
     {
         $messages = $this->messages()->where('user_id', '!=', $userId)->get();
 
@@ -449,7 +449,7 @@ class Thread extends Eloquent
      *
      * @return int
      */
-    public function userUnreadMessagesCount($userId): int
+    public function userUnreadMessagesCount($userId)
     {
         return $this->userUnreadMessages($userId)->count();
     }

--- a/src/Models/Thread.php
+++ b/src/Models/Thread.php
@@ -137,7 +137,7 @@ class Thread extends Eloquent
      *
      * @return Collection|static[]
      */
-    public static function getBySubject(string $subject)
+    public static function getBySubject($subject)
     {
         return static::where('subject', 'like', $subject)->get();
     }
@@ -349,7 +349,7 @@ class Thread extends Eloquent
      *
      * @return string
      */
-    public function participantsString($userId = null, array $columns = ['name'])
+    public function participantsString($userId = null, $columns = ['name'])
     {
         $participantsTable = Models::table('participants');
         $usersTable = Models::table('users');

--- a/src/Traits/Messagable.php
+++ b/src/Traits/Messagable.php
@@ -20,7 +20,7 @@ trait Messagable
      *
      * @codeCoverageIgnore
      */
-    public function messages(): HasMany
+    public function messages()
     {
         return $this->hasMany(Models::classname(Message::class));
     }
@@ -32,7 +32,7 @@ trait Messagable
      *
      * @codeCoverageIgnore
      */
-    public function participants(): HasMany
+    public function participants()
     {
         return $this->hasMany(Models::classname(Participant::class));
     }
@@ -44,7 +44,7 @@ trait Messagable
      *
      * @codeCoverageIgnore
      */
-    public function threads(): BelongsToMany
+    public function threads()
     {
         return $this->belongsToMany(
             Models::classname(Thread::class),
@@ -59,7 +59,7 @@ trait Messagable
      *
      * @return int
      */
-    public function newThreadsCount(): int
+    public function newThreadsCount()
     {
         return $this->threadsWithNewMessages()->count();
     }
@@ -69,7 +69,7 @@ trait Messagable
      *
      * @return int
      */
-    public function unreadMessagesCount(): int
+    public function unreadMessagesCount()
     {
         return Message::unreadForUser($this->getKey())->count();
     }
@@ -79,7 +79,7 @@ trait Messagable
      *
      * @return Collection
      */
-    public function threadsWithNewMessages(): Collection
+    public function threadsWithNewMessages()
     {
         return $this->threads()
             ->where(function (Builder $q) {


### PR DESCRIPTION
Fixes #377

The addition of types in #359 broke backward compatibility and semvar. These will be reintroduced in a future version