### PR TITLE
update date casting

### DIFF
--- a/src/Models/Message.php
+++ b/src/Models/Message.php
@@ -37,13 +37,6 @@ class Message extends Eloquent
     protected $fillable = ['thread_id', 'user_id', 'body'];
 
     /**
-     * The attributes that should be mutated to date's.
-     *
-     * @var array
-     */
-    protected $dates = ['deleted_at'];
-
-    /**
      * {@inheritDoc}
      */
     public function __construct(array $attributes = [])

--- a/src/Models/Participant.php
+++ b/src/Models/Participant.php
@@ -25,11 +25,11 @@ class Participant extends Eloquent
     protected $fillable = ['thread_id', 'user_id', 'last_read'];
 
     /**
-     * The attributes that should be mutated to date's.
+     * The attributes that should be cast.
      *
      * @var array
      */
-    protected $dates = ['deleted_at', 'last_read'];
+    protected $casts = ['last_read' => 'datetime'];
 
     /**
      * {@inheritDoc}

--- a/src/Models/Thread.php
+++ b/src/Models/Thread.php
@@ -36,13 +36,6 @@ class Thread extends Eloquent
     protected $fillable = ['subject'];
 
     /**
-     * The attributes that should be mutated to date's.
-     *
-     * @var array
-     */
-    protected $dates = ['deleted_at'];
-
-    /**
      * Internal cache for creator.
      *
      * @var null|Models::user()|\Illuminate\Database\Eloquent\Model


### PR DESCRIPTION
This PR updates the model's `$dates = []` to use `$casts = []`. This also drops the reference for the `deleted_at` field, which is redundant from using the `SoftDeletes` trait.

Anyone still using this package on Laravel versions `5.8`, or under, will have to:

1. Create their own models
2. Extend the package models
3. Re-add the `$dates = [...]` property
4. Reference the new models in the config file

Fixes #393